### PR TITLE
feat: use 'main' from plugin.yml to specify typescript entrypoint

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/customrealms/cli/internal/minecraft"
@@ -24,7 +25,6 @@ type BuildAction struct {
 }
 
 func (a *BuildAction) Run(ctx context.Context) error {
-
 	// Create the temp directory for the code output from Webpack.
 	// The code will be put into "bundle.js" in that directory
 	webpackOutputDir := filepath.Join(
@@ -32,29 +32,43 @@ func (a *BuildAction) Run(ctx context.Context) error {
 		fmt.Sprintf("cr-build-%d-%d", time.Now().Unix(), rand.Uint32()),
 	)
 	if err := os.MkdirAll(webpackOutputDir, 0777); err != nil {
-		return err
+		return fmt.Errorf("creating webpack output dir: %w", err)
 	}
 	defer os.RemoveAll(webpackOutputDir)
 
 	// Write the webpack configuration file temporarily
 	webpackConfigFile := filepath.Join(webpackOutputDir, "webpack.config.js")
 	if err := os.WriteFile(webpackConfigFile, []byte(webpackConfig), 0777); err != nil {
-		return err
+		return fmt.Errorf("write webpack config file: %w", err)
+	}
+
+	// Parse the plugin.yml file
+	pluginYML, err := a.Project.PluginYML()
+	if err != nil {
+		return fmt.Errorf("parse plugin.yml: %w", err)
 	}
 
 	fmt.Println("============================================================")
 	fmt.Println("Bundling JavaScript code using Webpack")
 	fmt.Println("============================================================")
 
+	// Determine the entrypoint for the TypeScript project
+	var entrypoint string
+	if pluginYML != nil && strings.HasSuffix(pluginYML.Main, ".ts") {
+		entrypoint = pluginYML.Main
+	} else {
+		entrypoint = "./src/main.ts"
+	}
+
 	// Build the local directory
-	err := a.Project.Exec(ctx, "npx", "webpack-cli",
+	err = a.Project.Exec(ctx, "npx", "webpack-cli",
 		"--mode=production",
 		"-o", webpackOutputDir,
 		"-c", webpackConfigFile,
-		"--entry", "./src/main.ts",
+		"--entry", entrypoint,
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("run webpack: %w", err)
 	}
 
 	fmt.Println()


### PR DESCRIPTION
This PR updates the `crx build` command to read from the `plugin.yml` file to determine the TypeScript entrypoint file for the plugin.

In Java plugins, the `main` field in `plugin.yml` is used to specify the classpath to the plugin's main class.

In CustomRealms plugins, this `main` field will instead be the relative path to the main TypeScript file for the plugin. The default will remain `./src/main.ts`